### PR TITLE
add example of render prop technique

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Awesome list of React components with render props and resources.
 - [Testing ⚛️ components using render props](https://blog.kentcdodds.com/5623ab1814c) by [Kent C. Dodds](https://twitter.com/kentcdodds)
 - [How to give rendering control to users with prop getters](https://blog.kentcdodds.com/549eaef76acf) by [Kent C. Dodds](https://twitter.com/kentcdodds)
 - [React’s ⚛️ new Context API](https://medium.com/dailyjs/reacts--new-context-api-70c9fe01596b) (uses a render prop, includes handy examples) by [Kent C. Dodds](https://twitter.com/kentcdodds)
+- [Render prop, Example of a component with styled components in defaultProps](https://medium.com/ableneo/example-of-a-component-with-styled-components-in-defaultprops-612c0f5ac386) by [Marcel Mokoš](https://twitter.com/marcelmokos)
+
 
 ## Components
 


### PR DESCRIPTION
Add component with styled components in defaultProps

- There are two articles where I was focusing on a technique that uses render props together with React defaultProps to create fully customizable components that enable to customize every subcomponent as well.
- both articles have examples in codesandbox and I prefer to attach an article with an example that has a link to an in-depth one. 

In-depth article:
- https://medium.com/ableneo/improve-how-you-style-react-apps-use-components-in-defaultprops-a8fd59e875d7

Article with an example:
- https://medium.com/ableneo/example-of-a-component-with-styled-components-in-defaultprops-612c0f5ac386

I hope you will like my contribution. Thanks for adding my article in, or for any valuable feedback.